### PR TITLE
remove source keyword in bind-key reference

### DIFF
--- a/scripts/kanagawa.sh
+++ b/scripts/kanagawa.sh
@@ -8,7 +8,7 @@ source $current_dir/colors.sh
 source $current_dir/theme.sh
 
 main() {
-  tmux bind-key -r T run-shell "source #{@kanagawa-root}/menu_items/main.sh"
+  tmux bind-key -r T run-shell "#{@kanagawa-root}/menu_items/main.sh"
 
   # set theme
   theme=$(get_tmux_option "@kanagawa-theme" "")


### PR DESCRIPTION
the keyword source when used with run-shell, in the bind-key statement, works correctly in tmux 3.4 under macOS (tested). However when switching to ubuntu (WSL2 version) and using the latest tmux available via apt (3.2a), the bound key fails with a "returned 127" error. the behavior persists when attempting to run any of the menu_items/*.sh scripts via the command line with the form tmux run-shell "source *.sh"

this change removes the source keyword from the bind-key reference. the change has not been checked with any additional operating systems or versions.