### PR TITLE
Changed all source references in menu_option scripts

### DIFF
--- a/menu_items/colors.sh
+++ b/menu_items/colors.sh
@@ -31,7 +31,7 @@ render() {
     "$dragon_title" 2 "run -b '#{@kanagawa-root}/scripts/actions.sh set_state_and_tmux_option theme dragon" \
     "$lotus_title" 3 "run -b '#{@kanagawa-root}/scripts/actions.sh set_state_and_tmux_option theme lotus" \
     "" \
-    "<-- Back" b "run -b 'source #{@kanagawa-root}/menu_items/main.sh" \
+    "<-- Back" b "run -b '#{@kanagawa-root}/menu_items/main.sh" \
     "Close menu" q ""
 }
 

--- a/menu_items/main.sh
+++ b/menu_items/main.sh
@@ -19,9 +19,9 @@ render() {
   tmux display-menu -T "#[align=centre fg=green]Main" -x R -y P \
     "" \
     "" \
-    "Colors" 1 "run -b 'source #{@kanagawa-root}/menu_items/colors.sh" \
-    "Plugins" 2 "run -b 'source #{@kanagawa-root}/menu_items/plugins.sh" \
-    "Options" 3 "run -b 'source #{@kanagawa-root}/menu_items/options.sh" \
+    "Colors" 1 "run -b '#{@kanagawa-root}/menu_items/colors.sh" \
+    "Plugins" 2 "run -b '#{@kanagawa-root}/menu_items/plugins.sh" \
+    "Options" 3 "run -b '#{@kanagawa-root}/menu_items/options.sh" \
     "" \
     "Close menu" q ""
 }

--- a/menu_items/options.sh
+++ b/menu_items/options.sh
@@ -29,12 +29,12 @@ get_option_title() {
 
 render() {
   tmux display-menu -T "#[align=centre fg=green]Options" -x R -y P \
-    "$(get_option_title show-powerline)" A "run -b 'source $ROOT_DIR/scripts/actions.sh toggle_option show-powerline; source $CURRENT_FILE'" \
-    "$(get_option_title show-fahrenheit)" B "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_option show-fahrenheit; tmux display-message \"Weather will be updated after next fetch.\"; source $CURRENT_FILE'" \
-    "$(get_option_title military-time)" C "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_option military-time; source $CURRENT_FILE'" \
-    "$(get_option_title show-flags)" D "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_option show-flags; source $CURRENT_FILE'" \
+    "$(get_option_title show-powerline)" A "run -b '$ROOT_DIR/scripts/actions.sh toggle_option show-powerline; source $CURRENT_FILE'" \
+    "$(get_option_title show-fahrenheit)" B "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_option show-fahrenheit; tmux display-message \"Weather will be updated after next fetch.\"; source $CURRENT_FILE'" \
+    "$(get_option_title military-time)" C "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_option military-time; source $CURRENT_FILE'" \
+    "$(get_option_title show-flags)" D "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_option show-flags; source $CURRENT_FILE'" \
     "" \
-    "<-- Back" b "run -b 'source #{@kanagawa-root}/menu_items/main.sh'" \
+    "<-- Back" b "run -b '#{@kanagawa-root}/menu_items/main.sh'" \
     "Close menu" q ""
 }
 

--- a/menu_items/plugins.sh
+++ b/menu_items/plugins.sh
@@ -4,7 +4,7 @@ CURRENT_FILE="${BASH_SOURCE[0]}"
 CURRENT_DIR="$(dirname -- "$(readlink -f -- "$0")")"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
 
-source "$ROOT_DIR/scripts/utils.sh"
+"$ROOT_DIR/scripts/utils.sh"
 
 available_plugins="battery cpu-usage git gpu-usage ram-usage tmux-ram-usage network network-bandwidth network-ping ssh-session attached-clients network-vpn weather time mpc spotify-tui playerctl kubernetes-context synchronize-panes"
 
@@ -22,27 +22,27 @@ render() {
   tmux display-menu -T "#[align=centre fg=green]Plugins" -x R -y P \
     "" \
     "" \
-    "$(get_plugin_title "battery")" A "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin battery; source $CURRENT_FILE" \
-    "$(get_plugin_title "cpu-usage")" B "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin cpu-usage; source $CURRENT_FILE" \
-    "$(get_plugin_title "git")" C "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin git; source $CURRENT_FILE" \
-    "$(get_plugin_title "gpu-usage")" D "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin gpu-usage; source $CURRENT_FILE" \
-    "$(get_plugin_title "ram-usage")" E "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin ram-usage; source $CURRENT_FILE" \
-    "$(get_plugin_title "tmux-ram-usage")" F "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin tmux-ram-usage; source $CURRENT_FILE" \
-    "$(get_plugin_title "network")" G "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin network; source $CURRENT_FILE" \
-    "$(get_plugin_title "network-bandwidth")" H "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin network-bandwidth; source $CURRENT_FILE" \
-    "$(get_plugin_title "network-ping")" I "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin network-ping; source $CURRENT_FILE" \
-    "$(get_plugin_title "ssh-session")" J "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin ssh-session; source $CURRENT_FILE" \
-    "$(get_plugin_title "attached-clients")" K "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin attached-clients; source $CURRENT_FILE" \
-    "$(get_plugin_title "network-vpn")" L "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin network-vpn; source $CURRENT_FILE" \
-    "$(get_plugin_title "weather")" M "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin weather; source $CURRENT_FILE" \
-    "$(get_plugin_title "time")" N "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin time; source $CURRENT_FILE" \
-    "$(get_plugin_title "mpc")" O "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin mpc; source $CURRENT_FILE" \
-    "$(get_plugin_title "spotify-tui")" P "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin spotify-tui; source $CURRENT_FILE" \
-    "$(get_plugin_title "playerctl")" Q "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin playerctl; source $CURRENT_FILE" \
-    "$(get_plugin_title "kubernetes-context")" R "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin kubernetes-context; source $CURRENT_FILE" \
-    "$(get_plugin_title "synchronize-panes")" S "run -b 'source #{@kanagawa-root}/scripts/actions.sh toggle_plugin synchronize-panes; source $CURRENT_FILE" \
+    "$(get_plugin_title "battery")" A "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin battery; source $CURRENT_FILE" \
+    "$(get_plugin_title "cpu-usage")" B "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin cpu-usage; source $CURRENT_FILE" \
+    "$(get_plugin_title "git")" C "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin git; source $CURRENT_FILE" \
+    "$(get_plugin_title "gpu-usage")" D "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin gpu-usage; source $CURRENT_FILE" \
+    "$(get_plugin_title "ram-usage")" E "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin ram-usage; source $CURRENT_FILE" \
+    "$(get_plugin_title "tmux-ram-usage")" F "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin tmux-ram-usage; source $CURRENT_FILE" \
+    "$(get_plugin_title "network")" G "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin network; source $CURRENT_FILE" \
+    "$(get_plugin_title "network-bandwidth")" H "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin network-bandwidth; source $CURRENT_FILE" \
+    "$(get_plugin_title "network-ping")" I "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin network-ping; source $CURRENT_FILE" \
+    "$(get_plugin_title "ssh-session")" J "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin ssh-session; source $CURRENT_FILE" \
+    "$(get_plugin_title "attached-clients")" K "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin attached-clients; source $CURRENT_FILE" \
+    "$(get_plugin_title "network-vpn")" L "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin network-vpn; source $CURRENT_FILE" \
+    "$(get_plugin_title "weather")" M "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin weather; source $CURRENT_FILE" \
+    "$(get_plugin_title "time")" N "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin time; source $CURRENT_FILE" \
+    "$(get_plugin_title "mpc")" O "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin mpc; source $CURRENT_FILE" \
+    "$(get_plugin_title "spotify-tui")" P "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin spotify-tui; source $CURRENT_FILE" \
+    "$(get_plugin_title "playerctl")" Q "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin playerctl; source $CURRENT_FILE" \
+    "$(get_plugin_title "kubernetes-context")" R "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin kubernetes-context; source $CURRENT_FILE" \
+    "$(get_plugin_title "synchronize-panes")" S "run -b '#{@kanagawa-root}/scripts/actions.sh toggle_plugin synchronize-panes; source $CURRENT_FILE" \
     "" \
-    "<-- Back" b "run -b 'source #{@kanagawa-root}/menu_items/main.sh" \
+    "<-- Back" b "run -b '#{@kanagawa-root}/menu_items/main.sh" \
     "Close menu" q ""
 }
 


### PR DESCRIPTION
Similiar to the previous PR submited, chadwpry/remove-incompatible-hotkey-ref-to-source, this PR removes all references to the source keyword when being used in the tmux run or run-shell definition.

Testing within my own branch to verify on both mac and windows environments.